### PR TITLE
Bump kotlin_version from 1.2.60 to 1.2.61 (#1050)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.60'
+    ext.kotlin_version = '1.2.61'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Bumps `kotlin_version` from 1.2.60 to 1.2.61.

Updates `kotlin-gradle-plugin` from 1.2.60 to 1.2.61
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/commits)

Updates `kotlin-stdlib-jdk7` from $kotlin_version to 1.2.61
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/commits)

Updates `kotlin-test-junit` from $kotlin_version to 1.2.61
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/commits)

Signed-off-by: dependabot[bot] <support@dependabot.com>

## Issue

This fixes the following issue(s):

## Screenshot

## Why this is useful for all students

